### PR TITLE
Fix missing namespace for Android plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 android {
+    namespace 'com.vaultsafe.mobile'
     compileSdkVersion 34
 
     defaultConfig {


### PR DESCRIPTION
## Summary
- set required `namespace` in `app/build.gradle`

## Testing
- `gradle test` *(fails: Could not resolve com.android.tools.build:gradle:8.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_6841f043f6d0832697ee424c8983701f