### PR TITLE
Fix manifest exported attribute

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,9 @@
         android:allowBackup="false"
         android:label="VaultSafe Mobile"
         android:theme="@style/Theme.VaultSafeMobile">
-        <activity android:name=".WelcomeActivity">
+        <activity
+            android:name=".WelcomeActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
## Summary
- add `android:exported` attribute to `WelcomeActivity`

## Testing
- `gradle test --no-daemon --console=plain -q` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421ab0c5f883268e99bd4bcb36b068