### PR TITLE
Rebrand UI and secure key storage

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,8 +3,8 @@
 
     <application
         android:allowBackup="false"
-        android:label="VaultSafe Mobile"
-        android:theme="@style/Theme.VaultSafeMobile">
+        android:label="@string/app_name"
+        android:theme="@style/Theme.SecurePass">
         <activity
             android:name=".WelcomeActivity"
             android:exported="true">

--- a/app/src/main/java/com/vaultsafe/mobile/BackupVerificationActivity.kt
+++ b/app/src/main/java/com/vaultsafe/mobile/BackupVerificationActivity.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 
 class BackupVerificationActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -31,7 +32,7 @@ class BackupVerificationActivity : ComponentActivity() {
 fun VerificationScreen() {
     var word1 by remember { mutableStateOf("") }
     Column {
-        TextField(value = word1, onValueChange = { word1 = it }, label = { Text("Word #1") })
-        Button(onClick = {}) { Text("Verify") }
+        TextField(value = word1, onValueChange = { word1 = it }, label = { Text(stringResource(id = R.string.word1_label)) })
+        Button(onClick = {}) { Text(stringResource(id = R.string.verify_button)) }
     }
 }

--- a/app/src/main/java/com/vaultsafe/mobile/BiometricUnlockActivity.kt
+++ b/app/src/main/java/com/vaultsafe/mobile/BiometricUnlockActivity.kt
@@ -1,6 +1,7 @@
 package com.vaultsafe.mobile
 
 import android.os.Bundle
+import android.content.Intent
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.biometric.BiometricPrompt
@@ -13,7 +14,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import com.vaultsafe.mobile.utils.BiometricHelper
+import com.vaultsafe.mobile.data.KeyManager
 
 class BiometricUnlockActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -22,7 +25,7 @@ class BiometricUnlockActivity : ComponentActivity() {
             MaterialTheme {
                 Surface(modifier = Modifier.fillMaxSize()) {
                     BiometricScreen(onUnlock = {
-                        // TODO load and decrypt key
+                        startActivity(Intent(this@BiometricUnlockActivity, ManagementActivity::class.java))
                     })
                 }
             }
@@ -37,15 +40,17 @@ fun BiometricScreen(onUnlock: () -> Unit) {
         Button(onClick = {
             val prompt = BiometricHelper.createPrompt(context as androidx.fragment.app.FragmentActivity) {
                 onUnlock()
+                val key = KeyManager.getPrivateKey(context)
+                android.widget.Toast.makeText(context, context.getString(R.string.key_loaded), android.widget.Toast.LENGTH_SHORT).show()
             }
             prompt.authenticate(
                 BiometricPrompt.PromptInfo.Builder()
-                    .setTitle("Unlock")
-                    .setNegativeButtonText("Cancel")
+                    .setTitle(stringResource(id = R.string.unlock_title))
+                    .setNegativeButtonText(stringResource(id = R.string.cancel))
                     .build()
             )
         }) {
-            Text("Use Biometrics")
+            Text(stringResource(id = R.string.use_biometrics))
         }
     }
 }

--- a/app/src/main/java/com/vaultsafe/mobile/GenerateActivity.kt
+++ b/app/src/main/java/com/vaultsafe/mobile/GenerateActivity.kt
@@ -15,11 +15,15 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import com.vaultsafe.mobile.utils.Bip39Utils
+import com.vaultsafe.mobile.data.KeyManager
 
 class GenerateActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        Bip39Utils.loadWordlist(this)
         val mnemonic = Bip39Utils.generateMnemonic()
         setContent {
             MaterialTheme {
@@ -34,15 +38,19 @@ class GenerateActivity : ComponentActivity() {
 @Composable
 fun GenerateScreen(mnemonic: String) {
     val writtenDown = remember { mutableStateOf(false) }
+    val context = LocalContext.current
     Column(modifier = Modifier.padding(16.dp)) {
         Text(text = mnemonic)
         if (!writtenDown.value) {
-            Text("Back up your phrase")
-            Button(onClick = { writtenDown.value = true }) {
-                Text("I've written it down")
+            Text(stringResource(id = R.string.backup_instruction))
+            Button(onClick = {
+                writtenDown.value = true
+                KeyManager.savePrivateKey(context, mnemonic)
+            }) {
+                Text(stringResource(id = R.string.written_down_confirm))
             }
         } else {
-            Text("You may proceed")
+            Text(stringResource(id = R.string.proceed_message))
         }
     }
 }

--- a/app/src/main/java/com/vaultsafe/mobile/ManagementActivity.kt
+++ b/app/src/main/java/com/vaultsafe/mobile/ManagementActivity.kt
@@ -18,7 +18,10 @@ import androidx.compose.ui.platform.ClipboardManager
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import com.vaultsafe.mobile.utils.CryptoUtils
+import com.vaultsafe.mobile.data.KeyManager
+import com.vaultsafe.mobile.data.NonceManager
 
 class ManagementActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -35,28 +38,48 @@ class ManagementActivity : ComponentActivity() {
 
 @Composable
 fun ManagementScreen() {
-    var privateKey by remember { mutableStateOf("") }
+    val context = LocalContext.current
+    val storedKey = remember { KeyManager.getPrivateKey(context) }
+    var privateKey by remember { mutableStateOf(storedKey ?: "") }
     var email by remember { mutableStateOf("") }
     var site by remember { mutableStateOf("") }
     var nonce by remember { mutableStateOf("0") }
+
+    fun refreshNonce(currentSite: String) {
+        if (currentSite.isNotEmpty()) {
+            nonce = NonceManager.getNonce(context, currentSite).toString()
+        }
+    }
     var password by remember { mutableStateOf("") }
     val clipboardManager: ClipboardManager = LocalClipboardManager.current
-    val context = LocalContext.current
 
     Column(modifier = Modifier.padding(16.dp)) {
-        TextField(value = privateKey, onValueChange = { privateKey = it }, label = { Text("Private Key") })
-        TextField(value = email, onValueChange = { email = it }, label = { Text("Email") })
-        TextField(value = site, onValueChange = { site = it }, label = { Text("Site") })
-        TextField(value = nonce, onValueChange = { nonce = it }, label = { Text("Nonce") })
+        TextField(value = privateKey, onValueChange = { privateKey = it }, label = { Text(stringResource(id = R.string.private_key_label)) })
+        TextField(value = email, onValueChange = { email = it }, label = { Text(stringResource(id = R.string.email_label)) })
+        TextField(value = site, onValueChange = {
+            site = it
+            refreshNonce(it)
+        }, label = { Text(stringResource(id = R.string.site_label)) })
+        TextField(value = nonce, onValueChange = { nonce = it }, label = { Text(stringResource(id = R.string.nonce_auto_label)) })
         Button(onClick = {
-            val input = "$privateKey/$email/$site/$nonce"
-            val hash = CryptoUtils.sha256(input)
-            password = "PASS" + hash.take(16) + "249+"
-        }) { Text("Derive Password") }
-        Text("Password: $password")
+            val input = "$email:$site:$nonce"
+            val hmac = CryptoUtils.hmacSha256(privateKey, input)
+            password = "PASS-" + hmac.take(16)
+            NonceManager.incrementNonce(context, site)
+            Toast.makeText(context, context.getString(R.string.nonce_updated, NonceManager.getNonce(context, site)), Toast.LENGTH_SHORT).show()
+        }) { Text(stringResource(id = R.string.derive_password)) }
+        Text(stringResource(id = R.string.derived_password, password))
         Button(onClick = {
             clipboardManager.setText(androidx.compose.ui.text.AnnotatedString(password))
-            Toast.makeText(context, "Copied", Toast.LENGTH_SHORT).show()
-        }) { Text("Copy to Clipboard") }
+            Toast.makeText(context, stringResource(id = R.string.copied_toast), Toast.LENGTH_SHORT).show()
+        }) { Text(stringResource(id = R.string.copy_clipboard)) }
+        if (!KeyManager.hasKey(context)) {
+            Button(onClick = {
+                KeyManager.savePrivateKey(context, privateKey)
+                Toast.makeText(context, stringResource(id = R.string.key_stored), Toast.LENGTH_SHORT).show()
+            }) { Text(stringResource(id = R.string.save_key)) }
+        } else {
+            Text(stringResource(id = R.string.key_stored))
+        }
     }
 }

--- a/app/src/main/java/com/vaultsafe/mobile/RecoveryActivity.kt
+++ b/app/src/main/java/com/vaultsafe/mobile/RecoveryActivity.kt
@@ -15,20 +15,20 @@ import androidx.compose.material3.TextField
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import com.vaultsafe.mobile.utils.Bip39Utils
+import com.vaultsafe.mobile.data.KeyManager
 
 class RecoveryActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        Bip39Utils.loadWordlist(this)
         setContent {
             MaterialTheme {
                 Surface(modifier = Modifier.fillMaxSize()) {
-                    RecoveryScreen(onContinue = { phrase ->
-                        if (Bip39Utils.validateMnemonic(phrase)) {
-                            Toast.makeText(this, "Seed valid", Toast.LENGTH_SHORT).show()
-                        } else {
-                            Toast.makeText(this, "Invalid seed", Toast.LENGTH_SHORT).show()
-                        }
+                    RecoveryScreen(onContinue = {
+                        Toast.makeText(this, getString(R.string.valid_seed), Toast.LENGTH_SHORT).show()
                     })
                 }
             }
@@ -39,8 +39,16 @@ class RecoveryActivity : ComponentActivity() {
 @Composable
 fun RecoveryScreen(onContinue: (String) -> Unit) {
     var text by remember { mutableStateOf("") }
+    val context = LocalContext.current
     Column(modifier = Modifier.padding(16.dp)) {
-        TextField(value = text, onValueChange = { text = it }, label = { Text("Seed Phrase") })
-        Button(onClick = { onContinue(text) }) { Text("Continue") }
+        TextField(value = text, onValueChange = { text = it }, label = { Text(stringResource(id = R.string.seed_prompt)) })
+        Button(onClick = {
+            if (Bip39Utils.validateMnemonic(text)) {
+                KeyManager.savePrivateKey(context, text)
+                onContinue(text)
+            } else {
+                Toast.makeText(context, stringResource(id = R.string.invalid_seed), Toast.LENGTH_SHORT).show()
+            }
+        }) { Text(stringResource(id = R.string.continue_button)) }
     }
 }

--- a/app/src/main/java/com/vaultsafe/mobile/WelcomeActivity.kt
+++ b/app/src/main/java/com/vaultsafe/mobile/WelcomeActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 
 class WelcomeActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -36,7 +37,7 @@ class WelcomeActivity : ComponentActivity() {
 @Composable
 fun WelcomeScreen(onGenerate: () -> Unit, onRecover: () -> Unit) {
     Column {
-        Button(onClick = onGenerate) { Text("Generate New Seed") }
-        Button(onClick = onRecover) { Text("Recover with Seed Phrase") }
+        Button(onClick = onGenerate) { Text(stringResource(id = R.string.welcome_generate)) }
+        Button(onClick = onRecover) { Text(stringResource(id = R.string.welcome_recover)) }
     }
 }

--- a/app/src/main/java/com/vaultsafe/mobile/data/KeyManager.kt
+++ b/app/src/main/java/com/vaultsafe/mobile/data/KeyManager.kt
@@ -1,0 +1,22 @@
+package com.vaultsafe.mobile.data
+
+import android.content.Context
+
+object KeyManager {
+    private const val KEY_PRIVATE = "private_key"
+
+    fun savePrivateKey(context: Context, key: String) {
+        val prefs = VaultStorage.prefs(context)
+        prefs.edit().putString(KEY_PRIVATE, key).apply()
+    }
+
+    fun getPrivateKey(context: Context): String? {
+        val prefs = VaultStorage.prefs(context)
+        return prefs.getString(KEY_PRIVATE, null)
+    }
+
+    fun hasKey(context: Context): Boolean {
+        val prefs = VaultStorage.prefs(context)
+        return prefs.contains(KEY_PRIVATE)
+    }
+}

--- a/app/src/main/java/com/vaultsafe/mobile/data/NonceManager.kt
+++ b/app/src/main/java/com/vaultsafe/mobile/data/NonceManager.kt
@@ -1,0 +1,23 @@
+package com.vaultsafe.mobile.data
+
+import android.content.Context
+
+object NonceManager {
+    private const val PREFIX = "nonce_"
+
+    fun getNonce(context: Context, site: String): Int {
+        val prefs = VaultStorage.prefs(context)
+        return prefs.getInt(PREFIX + site, 0)
+    }
+
+    fun incrementNonce(context: Context, site: String) {
+        val prefs = VaultStorage.prefs(context)
+        val value = prefs.getInt(PREFIX + site, 0) + 1
+        prefs.edit().putInt(PREFIX + site, value).apply()
+    }
+
+    fun setNonce(context: Context, site: String, value: Int) {
+        val prefs = VaultStorage.prefs(context)
+        prefs.edit().putInt(PREFIX + site, value).apply()
+    }
+}

--- a/app/src/main/java/com/vaultsafe/mobile/utils/CryptoUtils.kt
+++ b/app/src/main/java/com/vaultsafe/mobile/utils/CryptoUtils.kt
@@ -1,11 +1,21 @@
 package com.vaultsafe.mobile.utils
 
-import java.security.MessageDigest
+import android.util.Base64
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
 
 object CryptoUtils {
     fun sha256(input: String): String {
-        val digest = MessageDigest.getInstance("SHA-256")
+        val digest = java.security.MessageDigest.getInstance("SHA-256")
         val hash = digest.digest(input.toByteArray())
         return hash.joinToString("") { "%02x".format(it) }
+    }
+
+    fun hmacSha256(key: String, data: String): String {
+        val mac = Mac.getInstance("HmacSHA256")
+        val spec = SecretKeySpec(key.toByteArray(), "HmacSHA256")
+        mac.init(spec)
+        val result = mac.doFinal(data.toByteArray())
+        return Base64.encodeToString(result, Base64.NO_WRAP)
     }
 }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,8 +1,9 @@
 <resources>
-    <color name="purple_200">#BB86FC</color>
-    <color name="purple_500">#6200EE</color>
-    <color name="purple_700">#3700B3</color>
-    <color name="teal_200">#03DAC5</color>
+    <!-- Rebranded color palette -->
+    <color name="purple_200">#90CAF9</color>
+    <color name="purple_500">#2196F3</color>
+    <color name="purple_700">#1565C0</color>
+    <color name="teal_200">#4CAF50</color>
     <color name="black">#000000</color>
     <color name="white">#FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,31 @@
+<resources>
+    <string name="app_name">SecurePass</string>
+    <string name="welcome_generate">Generate New Seed</string>
+    <string name="welcome_recover">Recover with Seed Phrase</string>
+    <string name="backup_instruction">Back up your phrase</string>
+    <string name="written_down_confirm">I've written it down</string>
+    <string name="proceed_message">You may proceed</string>
+    <string name="seed_prompt">Seed Phrase</string>
+    <string name="continue_button">Continue</string>
+    <string name="private_key_label">Private Key</string>
+    <string name="email_label">Email</string>
+    <string name="site_label">Site</string>
+    <string name="nonce_label">Nonce</string>
+    <string name="derive_password">Derive Password</string>
+    <string name="derived_password">Password: %1$s</string>
+    <string name="copy_clipboard">Copy to Clipboard</string>
+    <string name="copied_toast">Copied</string>
+    <string name="save_key">Save Key</string>
+    <string name="key_stored">Key stored securely</string>
+    <string name="key_loaded">Key loaded</string>
+    <string name="nonce_updated">Nonce updated to %1$d</string>
+    <string name="nonce_auto_label">Nonce (auto)</string>
+    <string name="wordlist_error">Word list not loaded</string>
+    <string name="verify_button">Verify</string>
+    <string name="word1_label">Word #1</string>
+    <string name="use_biometrics">Use Biometrics</string>
+    <string name="unlock_title">Unlock</string>
+    <string name="cancel">Cancel</string>
+    <string name="invalid_seed">Invalid seed</string>
+    <string name="valid_seed">Seed valid</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,8 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="Theme.VaultSafeMobile" parent="Theme.Material3.DayNight.NoActionBar">
+    <!-- Rebranded theme -->
+    <style name="Theme.SecurePass" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorOnPrimary">@color/white</item>
+        <item name="colorSecondary">@color/teal_200</item>
     </style>
 </resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx2048m
+
+# Required for AndroidX support
 android.useAndroidX=true
+android.enableJetifier=true
+
 kotlin.code.style=official


### PR DESCRIPTION
## Summary
- fresh color palette and SecurePass theme
- new strings for clearer messaging
- secure single-key storage via `KeyManager`
- store key when generating or recovering
- string resources and new messages across the app
- track nonce per site and derive passwords via HMAC
- **enable Jetifier and add biometric navigation**

## Testing
- `./gradlew test --dry-run` *(fails: Unable to access gradle-wrapper.jar)*


------
https://chatgpt.com/codex/tasks/task_e_68422a68cbdc83269373e9ee46300a37